### PR TITLE
Fix restore failures from duplicate and vulnerable package versions

### DIFF
--- a/CrossRepoActions/CrossRepoActions.csproj
+++ b/CrossRepoActions/CrossRepoActions.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="NuGet.Versioning" />
     <PackageReference Include="Polyfill" />
     <PackageReference Include="System.Management.Automation" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,15 +19,14 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Abstractions" Version="1.78.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.78.0" />
     <PackageVersion Include="Microsoft.SemanticKernel.Core" Version="1.78.0" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="1.7.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.Fakes" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="1.7.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.HotReload" Version="1.7.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="1.7.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.2" />
+    <!-- Microsoft.Testing.Extensions.* versions are owned by MSTest.Sdk, which injects a matching
+         PackageVersion for every extension it references. Declaring them here duplicates those
+         entries and fails restore with NU1506. -->
     <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
     <PackageVersion Include="Polyfill" Version="11.0.1" />
     <PackageVersion Include="System.Management.Automation" Version="7.6.4" />
+    <!-- Transitive of Microsoft.PowerShell.SDK / System.Management.Automation; pinned forward off
+         the vulnerable 10.0.6 those packages resolve to (NU1903). -->
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

`dotnet build` was failing at restore for two independent reasons.

**`NU1506` — duplicate `PackageVersion` items (CrossRepoActions.Test)**

`Directory.Packages.props` pinned seven `Microsoft.Testing.Extensions.*` packages, but MSTest.Sdk 4.3.3 injects its own `PackageVersion` for every extension it references under central package management. CodeCoverage (18.9.0 vs. pinned 17.14.2) and TrxReport (2.3.3 vs. pinned 1.7.2) collided.

All seven entries are removed. This is safe because MSTest.Sdk always pairs each injected `PackageReference` with a matching `PackageVersion`, and the ktsu.Sdk KTSU0005 orphan analyzer explicitly skips the `Microsoft.Testing.Extensions.` prefix. The supported lever for controlling these versions is the `MicrosoftTestingExtensions*Version` properties, not `PackageVersion` entries.

**`NU1903` — high-severity vulnerability (both projects)**

`System.Security.Cryptography.Xml` 10.0.6 arrives transitively via Microsoft.PowerShell.SDK / System.Management.Automation and carries five advisories. Pinned forward to 10.0.10, with an explicit `PackageReference` in `CrossRepoActions.csproj` so KTSU0005 does not flag the version as orphaned. The test project picks it up through its `ProjectReference`.

## Test plan

- `dotnet build` — succeeds, 0 warnings, 0 errors
- `dotnet test` — 15/15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zdo5ANWj1oVmu3dHVZsuf